### PR TITLE
higher atomic write op limit

### DIFF
--- a/atomic_write_operation.go
+++ b/atomic_write_operation.go
@@ -5,9 +5,9 @@ type AtomicWriteResult interface {
 	ConditionalFailed() bool
 }
 
-// DynamoDB can't do more than 10 operations in an atomic write. So all stores should enforce this
+// DynamoDB can't do more than 25 operations in an atomic write. So all stores should enforce this
 // limit.
-const MaxAtomicWriteOperations = 10
+const MaxAtomicWriteOperations = 25
 
 type AtomicWriteOperation interface {
 	SetNX(key string, value interface{}) AtomicWriteResult

--- a/backend.go
+++ b/backend.go
@@ -6,7 +6,7 @@ type Backend interface {
 	// properties such as atomicity should not be assumed.
 	Batch() BatchOperation
 
-	// AtomicWrite executes up to 10 write operations atomically, failing entirely if any
+	// AtomicWrite executes up to 25 write operations atomically, failing entirely if any
 	// conditional operations (e.g. SetNX) are not executed.
 	AtomicWrite() AtomicWriteOperation
 


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-dynamodb-now-supports-up-to-25-unique-items-and-4-mb-of-data-per-transactional-request/