### PR TITLE
Batch deletes and zscores

### DIFF
--- a/dynamodbstore/batch_operation.go
+++ b/dynamodbstore/batch_operation.go
@@ -101,6 +101,14 @@ func (op *BatchOperation) Set(key string, value interface{}) keyvaluestore.Error
 	})
 }
 
+func (op *BatchOperation) Delete(key string) keyvaluestore.ErrorResult {
+	return op.batchWrite(key, "_", &dynamodb.WriteRequest{
+		DeleteRequest: &dynamodb.DeleteRequest{
+			Key: compositeKey(key, "_"),
+		},
+	})
+}
+
 func (op *BatchOperation) ZAdd(key string, member interface{}, score float64) keyvaluestore.ErrorResult {
 	s := *keyvaluestore.ToString(member)
 	return op.batchWrite(key, s, &dynamodb.WriteRequest{

--- a/keyvaluestorecache/batch_operation.go
+++ b/keyvaluestorecache/batch_operation.go
@@ -55,7 +55,7 @@ func (op *readCacheBatchOperation) Get(key string) keyvaluestore.GetResult {
 	return result
 }
 
-func (op *readCacheBatchOperation) Delete(key string) keyvaluestore.DeleteResult {
+func (op *readCacheBatchOperation) Delete(key string) keyvaluestore.ErrorResult {
 	op.invalidations = append(op.invalidations, key)
 	return op.batch.Delete(key)
 }

--- a/keyvaluestorecache/batch_operation.go
+++ b/keyvaluestorecache/batch_operation.go
@@ -7,6 +7,7 @@ type readCacheBatchOperation struct {
 
 	tryCache       []func()
 	getMisses      []boGetMiss
+	zscoreMisses   []boZScoreMiss
 	smembersMisses []boSMembersMiss
 	batch          keyvaluestore.BatchOperation
 	invalidations  []string
@@ -17,6 +18,13 @@ type boGetMiss struct {
 	Key    string
 	Dest   *boGetResult
 	Source keyvaluestore.GetResult
+}
+
+type boZScoreMiss struct {
+	Key    string
+	Member string
+	Dest   *boZScoreResult
+	Source keyvaluestore.ZScoreResult
 }
 
 type boSMembersMiss struct {
@@ -115,11 +123,45 @@ func (op *readCacheBatchOperation) ZRem(key string, member interface{}) keyvalue
 	return op.batch.ZRem(key, member)
 }
 
+type boZScoreResult struct {
+	score *float64
+	err   error
+}
+
+func (r *boZScoreResult) Result() (*float64, error) {
+	return r.score, r.err
+}
+
+func (op *readCacheBatchOperation) ZScore(key string, member interface{}) keyvaluestore.ZScoreResult {
+	result := &boZScoreResult{}
+	op.tryCache = append(op.tryCache, func() {
+		s := *keyvaluestore.ToString(member)
+		subkey := concatKeys("zs", s)
+		v, _ := op.ReadCache.load(key)
+		if zEntry, ok := v.(readCacheZEntry); ok {
+			if entry, ok := zEntry.subcache[subkey].(readCacheZScoreEntry); ok {
+				result.score, result.err = entry.score, entry.err
+				if result.err != nil && op.firstError == nil {
+					op.firstError = result.err
+				}
+				return
+			}
+		}
+		op.zscoreMisses = append(op.zscoreMisses, boZScoreMiss{
+			Key:    key,
+			Member: s,
+			Dest:   result,
+			Source: op.batch.ZScore(key, member),
+		})
+	})
+	return result
+}
+
 func (op *readCacheBatchOperation) Exec() error {
 	for _, f := range op.tryCache {
 		f()
 	}
-	if op.firstError != nil || len(op.getMisses)+len(op.smembersMisses)+len(op.invalidations) == 0 {
+	if op.firstError != nil || len(op.getMisses)+len(op.smembersMisses)+len(op.zscoreMisses)+len(op.invalidations) == 0 {
 		return op.firstError
 	}
 	err := op.batch.Exec()
@@ -131,6 +173,7 @@ func (op *readCacheBatchOperation) Exec() error {
 			err:   miss.Dest.err,
 		})
 	}
+
 	for _, miss := range op.smembersMisses {
 		miss.Dest.members, miss.Dest.err = miss.Source.Result()
 		op.ReadCache.store(miss.Key, readCacheSMembersEntry{
@@ -138,6 +181,22 @@ func (op *readCacheBatchOperation) Exec() error {
 			err:     miss.Dest.err,
 		})
 	}
+
+	for _, miss := range op.zscoreMisses {
+		miss.Dest.score, miss.Dest.err = miss.Source.Result()
+		subkey := concatKeys("zs", miss.Member)
+		v, _ := op.ReadCache.load(miss.Key)
+		zEntry, _ := v.(readCacheZEntry)
+		if zEntry.subcache == nil {
+			zEntry.subcache = make(map[string]interface{})
+		}
+		zEntry.subcache[subkey] = readCacheZScoreEntry{
+			score: miss.Dest.score,
+			err:   miss.Dest.err,
+		}
+		op.ReadCache.store(miss.Key, zEntry)
+	}
+
 	for _, key := range op.invalidations {
 		op.ReadCache.cache.Delete(key)
 	}

--- a/keyvaluestoretest/backend.go
+++ b/keyvaluestoretest/backend.go
@@ -483,6 +483,28 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 			assert.Equal(t, []string{"b", "a"}, members)
 			assert.NoError(t, err)
 		})
+
+		t.Run("ZScore", func(t *testing.T) {
+			b := newBackend()
+
+			assert.NoError(t, b.ZAdd("foo", "a", 0.0))
+			assert.NoError(t, b.ZAdd("foo", "b", 10.0))
+
+			batch := b.Batch()
+			rA := batch.ZScore("foo", "a")
+			rB := batch.ZScore("foo", "b")
+			absent := batch.ZScore("foo", "absent")
+			require.NoError(t, batch.Exec())
+
+			score, _ := rA.Result()
+			assert.Equal(t, 0.0, *score)
+
+			score, _ = rB.Result()
+			assert.Equal(t, 10.0, *score)
+
+			score, _ = absent.Result()
+			assert.Nil(t, score)
+		})
 	})
 
 	t.Run("SetEQ", func(t *testing.T) {

--- a/keyvaluestoretest/backend.go
+++ b/keyvaluestoretest/backend.go
@@ -431,6 +431,37 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("Delete", func(t *testing.T) {
+			b := newBackend()
+
+			batch := b.Batch()
+			batch.Set("foo", "a")
+			batch.Delete("foo")
+			require.NoError(t, batch.Exec())
+
+			foo, err := b.Get("foo")
+			assert.Nil(t, foo)
+			assert.NoError(t, err)
+
+			batch = b.Batch()
+			batch.Delete("foo")
+			require.NoError(t, batch.Exec())
+
+			foo, err = b.Get("foo")
+			assert.Nil(t, foo)
+			assert.NoError(t, err)
+
+			assert.NoError(t, b.Set("foo", "a"))
+
+			batch = b.Batch()
+			batch.Delete("foo")
+			require.NoError(t, batch.Exec())
+
+			foo, err = b.Get("foo")
+			assert.Nil(t, foo)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ZAdd", func(t *testing.T) {
 			b := newBackend()
 

--- a/redisstore/batch_operation.go
+++ b/redisstore/batch_operation.go
@@ -101,6 +101,26 @@ func (op *BatchOperation) ZRem(key string, member interface{}) keyvaluestore.Err
 	}
 }
 
+type ZScoreResult struct {
+	*redis.FloatCmd
+}
+
+func (r *ZScoreResult) Result() (*float64, error) {
+	v, err := r.FloatCmd.Result()
+	if err == redis.Nil {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func (op *BatchOperation) ZScore(key string, member interface{}) keyvaluestore.ZScoreResult {
+	return &ZScoreResult{
+		op.pipe.ZScore(key, *keyvaluestore.ToString(member)),
+	}
+}
+
 func (op *BatchOperation) Exec() error {
 	cmds, _ := op.pipe.Exec()
 	for _, cmd := range cmds {

--- a/redisstore/batch_operation.go
+++ b/redisstore/batch_operation.go
@@ -42,14 +42,6 @@ type RedisCmd interface {
 	Err() error
 }
 
-type DeleteResult struct {
-	*redis.IntCmd
-}
-
-func (r *DeleteResult) Result() (bool, error) {
-	return r.IntCmd.Val() > 0, r.IntCmd.Err()
-}
-
 type ErrorResult struct {
 	RedisCmd
 }
@@ -70,8 +62,8 @@ func (op *BatchOperation) Set(key string, value interface{}) keyvaluestore.Error
 	}
 }
 
-func (op *BatchOperation) Delete(key string) keyvaluestore.DeleteResult {
-	return &DeleteResult{
+func (op *BatchOperation) Delete(key string) keyvaluestore.ErrorResult {
+	return &ErrorResult{
 		op.pipe.Del(key),
 	}
 }


### PR DESCRIPTION
Makes deletes batchable for DynamoDB by removing the boolean result value. This is a backwards-incompatible change that will be evident at compile time. Previously deletes performed on DynamoDB batch operations were not actually batched, so there's no loss in functionality here.

Also makes ZScore available as a batch operation.