### PR TITLE
add hset, hdel, hget, hgetall

### DIFF
--- a/atomic_write_operation.go
+++ b/atomic_write_operation.go
@@ -46,10 +46,10 @@ type AtomicWriteOperation interface {
 	SRem(key string, member interface{}, members ...interface{}) AtomicWriteResult
 
 	// Sets one or more fields of the hash at the given key. No conditionals are applied.
-	HSet(key string, field KeyValue, fields ...KeyValue) AtomicWriteResult
+	HSet(key, field string, value interface{}, fields ...KeyValue) AtomicWriteResult
 
 	// Deletes one or more fields of the hash at the given key. No conditionals are applied.
-	HDel(key string, field string, fields ...string) AtomicWriteResult
+	HDel(key, field string, fields ...string) AtomicWriteResult
 
 	// Executes the operation. If a condition failed, returns false.
 	Exec() (bool, error)

--- a/atomic_write_operation.go
+++ b/atomic_write_operation.go
@@ -45,6 +45,12 @@ type AtomicWriteOperation interface {
 	// Removes a member from a set. No conditionals are applied.
 	SRem(key string, member interface{}, members ...interface{}) AtomicWriteResult
 
+	// Sets one or more fields of the hash at the given key. No conditionals are applied.
+	HSet(key string, field KeyValue, fields ...KeyValue) AtomicWriteResult
+
+	// Deletes one or more fields of the hash at the given key. No conditionals are applied.
+	HDel(key string, field string, fields ...string) AtomicWriteResult
+
 	// Executes the operation. If a condition failed, returns false.
 	Exec() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -1,5 +1,10 @@
 package keyvaluestore
 
+type KeyValue struct {
+	Key   string
+	Value interface{}
+}
+
 type Backend interface {
 	// Batch allows you to batch up simple operations for better performance potential. Use this
 	// only for possible performance benefits. Read isolation is implementation-defined and other
@@ -36,6 +41,20 @@ type Backend interface {
 
 	// Get members of a set.
 	SMembers(key string) ([]string, error)
+
+	// Sets one or more fields of the hash at the given key. If no hash exists at the key, a new one
+	// is created. Hashes are ideal for small sizes, but have implementation-dependent size
+	// limitations (400KB for DynamoDB). For large or unbounded sets, use something else.
+	HSet(key string, field KeyValue, fields ...KeyValue) error
+
+	// Deletes one or more fields of the hash at the given key.
+	HDel(key string, field string, fields ...string) error
+
+	// Gets a field of the hash at the given key or nil if the hash or field does not exist.
+	HGet(key, field string) (*string, error)
+
+	// Gets all fields of the hash at the given key.
+	HGetAll(key string) (map[string]string, error)
 
 	// Add to or create a sorted set.
 	ZAdd(key string, member interface{}, score float64) error

--- a/backend.go
+++ b/backend.go
@@ -45,10 +45,10 @@ type Backend interface {
 	// Sets one or more fields of the hash at the given key. If no hash exists at the key, a new one
 	// is created. Hashes are ideal for small sizes, but have implementation-dependent size
 	// limitations (400KB for DynamoDB). For large or unbounded sets, use something else.
-	HSet(key string, field KeyValue, fields ...KeyValue) error
+	HSet(key, field string, value interface{}, fields ...KeyValue) error
 
 	// Deletes one or more fields of the hash at the given key.
-	HDel(key string, field string, fields ...string) error
+	HDel(key, field string, fields ...string) error
 
 	// Gets a field of the hash at the given key or nil if the hash or field does not exist.
 	HGet(key, field string) (*string, error)

--- a/dynamodbstore/atomic_write_operation.go
+++ b/dynamodbstore/atomic_write_operation.go
@@ -172,14 +172,14 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 	})
 }
 
-func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
 	assignments := make([]string, 0, 1+len(fields))
 	names := make(map[string]*string, 1+len(fields))
 	values := make(map[string]*dynamodb.AttributeValue, 1+len(fields))
 	assignments = append(assignments, "#n0 = :v0")
-	names["#n0"] = aws.String(encodeHashFieldName(field.Key))
+	names["#n0"] = aws.String(encodeHashFieldName(field))
 	values[":v0"] = &dynamodb.AttributeValue{
-		B: []byte(*keyvaluestore.ToString(field.Value)),
+		B: []byte(*keyvaluestore.ToString(value)),
 	}
 	for i, field := range fields {
 		namePlaceholder := "#n" + strconv.Itoa(i+1)
@@ -201,7 +201,7 @@ func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, f
 	})
 }
 
-func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) HDel(key, field string, fields ...string) keyvaluestore.AtomicWriteResult {
 	placeholders := make([]string, 0, 1+len(fields))
 	names := make(map[string]*string, 1+len(fields))
 	placeholders = append(placeholders, "#n0")

--- a/dynamodbstore/atomic_write_operation.go
+++ b/dynamodbstore/atomic_write_operation.go
@@ -3,6 +3,8 @@ package dynamodbstore
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -166,6 +168,55 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 					BS: serializeSMembers(member, members...),
 				},
 			},
+		},
+	})
+}
+
+func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+	assignments := make([]string, 0, 1+len(fields))
+	names := make(map[string]*string, 1+len(fields))
+	values := make(map[string]*dynamodb.AttributeValue, 1+len(fields))
+	assignments = append(assignments, "#n0 = :v0")
+	names["#n0"] = aws.String(encodeHashFieldName(field.Key))
+	values[":v0"] = &dynamodb.AttributeValue{
+		B: []byte(*keyvaluestore.ToString(field.Value)),
+	}
+	for i, field := range fields {
+		namePlaceholder := "#n" + strconv.Itoa(i+1)
+		valuePlaceholder := ":v" + strconv.Itoa(i+1)
+		assignments = append(assignments, namePlaceholder+" = "+valuePlaceholder)
+		names[namePlaceholder] = aws.String(encodeHashFieldName(field.Key))
+		values[valuePlaceholder] = &dynamodb.AttributeValue{
+			B: []byte(*keyvaluestore.ToString(field.Value)),
+		}
+	}
+	return op.write(dynamodb.TransactWriteItem{
+		Update: &dynamodb.Update{
+			Key:                       compositeKey(key, "_"),
+			TableName:                 &op.Backend.TableName,
+			UpdateExpression:          aws.String("SET " + strings.Join(assignments, ", ")),
+			ExpressionAttributeNames:  names,
+			ExpressionAttributeValues: values,
+		},
+	})
+}
+
+func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+	placeholders := make([]string, 0, 1+len(fields))
+	names := make(map[string]*string, 1+len(fields))
+	placeholders = append(placeholders, "#n0")
+	names["#n0"] = aws.String(encodeHashFieldName(field))
+	for i, field := range fields {
+		placeholder := "#n" + strconv.Itoa(i+1)
+		placeholders = append(placeholders, placeholder)
+		names[placeholder] = aws.String(encodeHashFieldName(field))
+	}
+	return op.write(dynamodb.TransactWriteItem{
+		Update: &dynamodb.Update{
+			Key:                      compositeKey(key, "_"),
+			TableName:                &op.Backend.TableName,
+			UpdateExpression:         aws.String("REMOVE " + strings.Join(placeholders, ", ")),
+			ExpressionAttributeNames: names,
 		},
 	})
 }

--- a/dynamodbstore/backend.go
+++ b/dynamodbstore/backend.go
@@ -2,6 +2,7 @@ package dynamodbstore
 
 import (
 	"encoding"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -294,6 +295,112 @@ func (b *Backend) SMembers(key string) ([]string, error) {
 		return nil, nil
 	}
 	return attributeStringSliceValue(result.Item["v"]), nil
+}
+
+func encodeHashFieldName(name string) string {
+	return "~" + base64.RawURLEncoding.EncodeToString([]byte(name))
+}
+
+func decodeHashFieldName(name string) string {
+	if !strings.HasPrefix(name, "~") {
+		return ""
+	}
+	b, _ := base64.RawURLEncoding.DecodeString(name[1:])
+	return string(b)
+}
+
+func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+	assignments := make([]string, 0, 1+len(fields))
+	names := make(map[string]*string, 1+len(fields))
+	values := make(map[string]*dynamodb.AttributeValue, 1+len(fields))
+	assignments = append(assignments, "#n0 = :v0")
+	names["#n0"] = aws.String(encodeHashFieldName(field.Key))
+	values[":v0"] = &dynamodb.AttributeValue{
+		B: []byte(*keyvaluestore.ToString(field.Value)),
+	}
+	for i, field := range fields {
+		namePlaceholder := "#n" + strconv.Itoa(i+1)
+		valuePlaceholder := ":v" + strconv.Itoa(i+1)
+		assignments = append(assignments, namePlaceholder+" = "+valuePlaceholder)
+		names[namePlaceholder] = aws.String(encodeHashFieldName(field.Key))
+		values[valuePlaceholder] = &dynamodb.AttributeValue{
+			B: []byte(*keyvaluestore.ToString(field.Value)),
+		}
+	}
+	if _, err := b.Client.UpdateItem(&dynamodb.UpdateItemInput{
+		Key:                       compositeKey(key, "_"),
+		TableName:                 aws.String(b.TableName),
+		UpdateExpression:          aws.String("SET " + strings.Join(assignments, ", ")),
+		ExpressionAttributeNames:  names,
+		ExpressionAttributeValues: values,
+	}); err != nil {
+		return errors.Wrap(err, "dynamodb update item request error")
+	}
+	return nil
+}
+
+func (b *Backend) HDel(key string, field string, fields ...string) error {
+	placeholders := make([]string, 0, 1+len(fields))
+	names := make(map[string]*string, 1+len(fields))
+	placeholders = append(placeholders, "#n0")
+	names["#n0"] = aws.String(encodeHashFieldName(field))
+	for i, field := range fields {
+		placeholder := "#n" + strconv.Itoa(i+1)
+		placeholders = append(placeholders, placeholder)
+		names[placeholder] = aws.String(encodeHashFieldName(field))
+	}
+	if _, err := b.Client.UpdateItem(&dynamodb.UpdateItemInput{
+		Key:                      compositeKey(key, "_"),
+		TableName:                aws.String(b.TableName),
+		UpdateExpression:         aws.String("REMOVE " + strings.Join(placeholders, ", ")),
+		ExpressionAttributeNames: names,
+	}); err != nil {
+		return errors.Wrap(err, "dynamodb update item request error")
+	}
+	return nil
+}
+
+func (b *Backend) HGet(key, field string) (*string, error) {
+	attributeName := encodeHashFieldName(field)
+	result, err := b.Client.GetItem(&dynamodb.GetItemInput{
+		Key:                  compositeKey(key, "_"),
+		TableName:            aws.String(b.TableName),
+		ProjectionExpression: aws.String("#n"),
+		ExpressionAttributeNames: map[string]*string{
+			"#n": &attributeName,
+		},
+		ConsistentRead: aws.Bool(!b.AllowEventuallyConsistentReads),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "dynamodb get item request error")
+	}
+	if result.Item == nil || result.Item[attributeName] == nil {
+		return nil, nil
+	}
+	return attributeStringValue(result.Item[attributeName]), nil
+}
+
+func (b *Backend) HGetAll(key string) (map[string]string, error) {
+	result, err := b.Client.GetItem(&dynamodb.GetItemInput{
+		Key:            compositeKey(key, "_"),
+		TableName:      aws.String(b.TableName),
+		ConsistentRead: aws.Bool(!b.AllowEventuallyConsistentReads),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "dynamodb get item request error")
+	}
+	if result.Item == nil {
+		return nil, nil
+	}
+	ret := make(map[string]string, len(result.Item))
+	for k, v := range result.Item {
+		if name := decodeHashFieldName(k); name != "" {
+			if v := attributeStringValue(v); v != nil {
+				ret[name] = *v
+			}
+		}
+	}
+	return ret, nil
 }
 
 const floatSortKeyNumBytes = 8

--- a/dynamodbstore/backend.go
+++ b/dynamodbstore/backend.go
@@ -309,14 +309,14 @@ func decodeHashFieldName(name string) string {
 	return string(b)
 }
 
-func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+func (b *Backend) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) error {
 	assignments := make([]string, 0, 1+len(fields))
 	names := make(map[string]*string, 1+len(fields))
 	values := make(map[string]*dynamodb.AttributeValue, 1+len(fields))
 	assignments = append(assignments, "#n0 = :v0")
-	names["#n0"] = aws.String(encodeHashFieldName(field.Key))
+	names["#n0"] = aws.String(encodeHashFieldName(field))
 	values[":v0"] = &dynamodb.AttributeValue{
-		B: []byte(*keyvaluestore.ToString(field.Value)),
+		B: []byte(*keyvaluestore.ToString(value)),
 	}
 	for i, field := range fields {
 		namePlaceholder := "#n" + strconv.Itoa(i+1)
@@ -339,7 +339,7 @@ func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyva
 	return nil
 }
 
-func (b *Backend) HDel(key string, field string, fields ...string) error {
+func (b *Backend) HDel(key, field string, fields ...string) error {
 	placeholders := make([]string, 0, 1+len(fields))
 	names := make(map[string]*string, 1+len(fields))
 	placeholders = append(placeholders, "#n0")

--- a/keyvaluestorecache/atomic_write_operation.go
+++ b/keyvaluestorecache/atomic_write_operation.go
@@ -64,12 +64,12 @@ func (op *readCacheAtomicWriteOperation) SRem(key string, member interface{}, me
 	return op.atomicWrite.SRem(key, member, members...)
 }
 
-func (op *readCacheAtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+func (op *readCacheAtomicWriteOperation) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
 	op.invalidations = append(op.invalidations, key)
-	return op.atomicWrite.HSet(key, field, fields...)
+	return op.atomicWrite.HSet(key, field, value, fields...)
 }
 
-func (op *readCacheAtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+func (op *readCacheAtomicWriteOperation) HDel(key, field string, fields ...string) keyvaluestore.AtomicWriteResult {
 	op.invalidations = append(op.invalidations, key)
 	return op.atomicWrite.HDel(key, field, fields...)
 }

--- a/keyvaluestorecache/atomic_write_operation.go
+++ b/keyvaluestorecache/atomic_write_operation.go
@@ -64,6 +64,16 @@ func (op *readCacheAtomicWriteOperation) SRem(key string, member interface{}, me
 	return op.atomicWrite.SRem(key, member, members...)
 }
 
+func (op *readCacheAtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+	op.invalidations = append(op.invalidations, key)
+	return op.atomicWrite.HSet(key, field, fields...)
+}
+
+func (op *readCacheAtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+	op.invalidations = append(op.invalidations, key)
+	return op.atomicWrite.HDel(key, field, fields...)
+}
+
 func (op *readCacheAtomicWriteOperation) Exec() (bool, error) {
 	ret, err := op.atomicWrite.Exec()
 	for _, key := range op.invalidations {

--- a/keyvaluestorecache/read_cache.go
+++ b/keyvaluestorecache/read_cache.go
@@ -140,13 +140,13 @@ func (c *ReadCache) SRem(key string, member interface{}, members ...interface{})
 	return err
 }
 
-func (c *ReadCache) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
-	err := c.backend.HSet(key, field, fields...)
+func (c *ReadCache) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) error {
+	err := c.backend.HSet(key, field, value, fields...)
 	c.Invalidate(key)
 	return err
 }
 
-func (c *ReadCache) HDel(key string, field string, fields ...string) error {
+func (c *ReadCache) HDel(key, field string, fields ...string) error {
 	err := c.backend.HDel(key, field, fields...)
 	c.Invalidate(key)
 	return err

--- a/keyvaluestorecache/read_cache.go
+++ b/keyvaluestorecache/read_cache.go
@@ -140,6 +140,70 @@ func (c *ReadCache) SRem(key string, member interface{}, members ...interface{})
 	return err
 }
 
+func (c *ReadCache) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+	err := c.backend.HSet(key, field, fields...)
+	c.Invalidate(key)
+	return err
+}
+
+func (c *ReadCache) HDel(key string, field string, fields ...string) error {
+	err := c.backend.HDel(key, field, fields...)
+	c.Invalidate(key)
+	return err
+}
+
+type hGetResult struct {
+	value *string
+	err   error
+}
+
+type readCacheHGetsEntry struct {
+	fields map[string]hGetResult
+}
+
+type readCacheHGetAllEntry struct {
+	fields map[string]string
+	err    error
+}
+
+func (c *ReadCache) HGet(key, field string) (*string, error) {
+	e, _ := c.load(key)
+	if entry, ok := e.(readCacheHGetAllEntry); ok {
+		if entry.err != nil {
+			return nil, entry.err
+		}
+		if v, ok := entry.fields[field]; ok {
+			return &v, nil
+		}
+		return nil, nil
+	}
+	entry, ok := e.(readCacheHGetsEntry)
+	if ok {
+		if r, ok := entry.fields[field]; ok {
+			return r.value, r.err
+		}
+	} else {
+		entry.fields = map[string]hGetResult{}
+	}
+	v, err := c.backend.HGet(key, field)
+	entry.fields[field] = hGetResult{
+		value: v,
+		err:   err,
+	}
+	c.store(key, entry)
+	return v, err
+}
+
+func (c *ReadCache) HGetAll(key string) (map[string]string, error) {
+	v, _ := c.load(key)
+	entry, ok := v.(readCacheHGetAllEntry)
+	if !ok {
+		entry.fields, entry.err = c.backend.HGetAll(key)
+		c.store(key, entry)
+	}
+	return entry.fields, entry.err
+}
+
 type readCacheSMembersEntry struct {
 	members []string
 	err     error

--- a/keyvaluestoretest/backend.go
+++ b/keyvaluestoretest/backend.go
@@ -289,6 +289,57 @@ func TestBackendAtomicWrite(t *testing.T, newBackend func() keyvaluestore.Backen
 			assert.Len(t, members, 1)
 		})
 	})
+
+	t.Run("HSet", func(t *testing.T) {
+		assert.NoError(t, b.Set("setcond", "foo"))
+
+		tx := b.AtomicWrite()
+		defer assertConditionFail(t, tx.SetNX("setcond", "foo"))
+		defer assertConditionPass(t, tx.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+		ok, err := tx.Exec()
+		assert.NoError(t, err)
+		assert.False(t, ok)
+
+		v, err := b.HGet("h", "foo")
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+
+		tx = b.AtomicWrite()
+		defer assertConditionPass(t, tx.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+		ok, err = tx.Exec()
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		v, err = b.HGet("h", "foo")
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", *v)
+	})
+
+	t.Run("HDel", func(t *testing.T) {
+		assert.NoError(t, b.Set("setcond", "foo"))
+		assert.NoError(t, b.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+
+		tx := b.AtomicWrite()
+		defer assertConditionFail(t, tx.SetNX("setcond", "foo"))
+		defer assertConditionPass(t, tx.HDel("h", "foo"))
+		ok, err := tx.Exec()
+		assert.NoError(t, err)
+		assert.False(t, ok)
+
+		v, err := b.HGet("h", "foo")
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", *v)
+
+		tx = b.AtomicWrite()
+		defer assertConditionPass(t, tx.HDel("h", "foo"))
+		ok, err = tx.Exec()
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		v, err = b.HGet("h", "foo")
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+	})
 }
 
 func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
@@ -434,6 +485,50 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 
 			assert.NoError(t, b.SRem("foo", "x"))
 		})
+	})
+
+	t.Run("HGet", func(t *testing.T) {
+		b := newBackend()
+
+		v, err := b.HGet("foo", "bar")
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+
+		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}))
+
+		v, err = b.HGet("foo", "bar")
+		assert.NoError(t, err)
+		assert.Equal(t, *v, "baz")
+	})
+
+	t.Run("HDel", func(t *testing.T) {
+		b := newBackend()
+
+		assert.NoError(t, b.HDel("foo", "bar"))
+
+		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}))
+
+		v, err := b.HGet("foo", "bar")
+		assert.NoError(t, err)
+		assert.NotNil(t, v)
+
+		assert.NoError(t, b.HDel("foo", "bar"))
+
+		v, err = b.HGet("foo", "bar")
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+	})
+
+	t.Run("HGetAll", func(t *testing.T) {
+		b := newBackend()
+
+		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}, keyvaluestore.KeyValue{"baz", "qux"}))
+
+		m, err := b.HGetAll("foo")
+		assert.NoError(t, err)
+		assert.Len(t, m, 2)
+		assert.Equal(t, "baz", m["bar"])
+		assert.Equal(t, "qux", m["baz"])
 	})
 
 	t.Run("AtomicWrite", func(t *testing.T) {

--- a/keyvaluestoretest/backend.go
+++ b/keyvaluestoretest/backend.go
@@ -295,7 +295,7 @@ func TestBackendAtomicWrite(t *testing.T, newBackend func() keyvaluestore.Backen
 
 		tx := b.AtomicWrite()
 		defer assertConditionFail(t, tx.SetNX("setcond", "foo"))
-		defer assertConditionPass(t, tx.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+		defer assertConditionPass(t, tx.HSet("h", "foo", "bar"))
 		ok, err := tx.Exec()
 		assert.NoError(t, err)
 		assert.False(t, ok)
@@ -305,7 +305,7 @@ func TestBackendAtomicWrite(t *testing.T, newBackend func() keyvaluestore.Backen
 		assert.Nil(t, v)
 
 		tx = b.AtomicWrite()
-		defer assertConditionPass(t, tx.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+		defer assertConditionPass(t, tx.HSet("h", "foo", "bar"))
 		ok, err = tx.Exec()
 		assert.NoError(t, err)
 		assert.True(t, ok)
@@ -317,7 +317,7 @@ func TestBackendAtomicWrite(t *testing.T, newBackend func() keyvaluestore.Backen
 
 	t.Run("HDel", func(t *testing.T) {
 		assert.NoError(t, b.Set("setcond", "foo"))
-		assert.NoError(t, b.HSet("h", keyvaluestore.KeyValue{"foo", "bar"}))
+		assert.NoError(t, b.HSet("h", "foo", "bar"))
 
 		tx := b.AtomicWrite()
 		defer assertConditionFail(t, tx.SetNX("setcond", "foo"))
@@ -494,7 +494,7 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 		assert.NoError(t, err)
 		assert.Nil(t, v)
 
-		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}))
+		assert.NoError(t, b.HSet("foo", "bar", "baz"))
 
 		v, err = b.HGet("foo", "bar")
 		assert.NoError(t, err)
@@ -506,7 +506,7 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 
 		assert.NoError(t, b.HDel("foo", "bar"))
 
-		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}))
+		assert.NoError(t, b.HSet("foo", "bar", "baz"))
 
 		v, err := b.HGet("foo", "bar")
 		assert.NoError(t, err)
@@ -522,7 +522,7 @@ func TestBackend(t *testing.T, newBackend func() keyvaluestore.Backend) {
 	t.Run("HGetAll", func(t *testing.T) {
 		b := newBackend()
 
-		assert.NoError(t, b.HSet("foo", keyvaluestore.KeyValue{"bar", "baz"}, keyvaluestore.KeyValue{"baz", "qux"}))
+		assert.NoError(t, b.HSet("foo", "bar", "baz", keyvaluestore.KeyValue{"baz", "qux"}))
 
 		m, err := b.HGetAll("foo")
 		assert.NoError(t, err)

--- a/memorystore/atomic_write_operation.go
+++ b/memorystore/atomic_write_operation.go
@@ -131,15 +131,15 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 	})
 }
 
-func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
 		write: func() {
-			op.Backend.hset(key, field, fields...)
+			op.Backend.hset(key, field, value, fields...)
 		},
 	})
 }
 
-func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) HDel(key, field string, fields ...string) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
 		write: func() {
 			op.Backend.hdel(key, field, fields...)

--- a/memorystore/atomic_write_operation.go
+++ b/memorystore/atomic_write_operation.go
@@ -131,6 +131,22 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 	})
 }
 
+func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+	return op.write(&atomicWriteOperation{
+		write: func() {
+			op.Backend.hset(key, field, fields...)
+		},
+	})
+}
+
+func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+	return op.write(&atomicWriteOperation{
+		write: func() {
+			op.Backend.hdel(key, field, fields...)
+		},
+	})
+}
+
 func (op *AtomicWriteOperation) Exec() (bool, error) {
 	if len(op.operations) > keyvaluestore.MaxAtomicWriteOperations {
 		return false, fmt.Errorf("max operation count exceeded")

--- a/memorystore/backend.go
+++ b/memorystore/backend.go
@@ -153,18 +153,18 @@ func (b *Backend) SMembers(key string) ([]string, error) {
 	return results, nil
 }
 
-func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+func (b *Backend) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	return b.hset(key, field, fields...)
+	return b.hset(key, field, value, fields...)
 }
 
-func (b *Backend) hset(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+func (b *Backend) hset(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) error {
 	h, ok := b.m[key].(map[string]string)
 	if !ok {
 		h = make(map[string]string)
 	}
-	h[field.Key] = *keyvaluestore.ToString(field.Value)
+	h[field] = *keyvaluestore.ToString(value)
 	for _, field := range fields {
 		h[field.Key] = *keyvaluestore.ToString(field.Value)
 	}

--- a/memorystore/backend.go
+++ b/memorystore/backend.go
@@ -134,8 +134,6 @@ func (b *Backend) srem(key string, member interface{}, members ...interface{}) e
 	}
 	if len(s) == 0 {
 		delete(b.m, key)
-	} else {
-		b.m[key] = s
 	}
 	return nil
 }
@@ -153,6 +151,68 @@ func (b *Backend) SMembers(key string) ([]string, error) {
 		results = append(results, k)
 	}
 	return results, nil
+}
+
+func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.hset(key, field, fields...)
+}
+
+func (b *Backend) hset(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+	h, ok := b.m[key].(map[string]string)
+	if !ok {
+		h = make(map[string]string)
+	}
+	h[field.Key] = *keyvaluestore.ToString(field.Value)
+	for _, field := range fields {
+		h[field.Key] = *keyvaluestore.ToString(field.Value)
+	}
+	b.m[key] = h
+	return nil
+}
+
+func (b *Backend) HDel(key string, field string, fields ...string) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.hdel(key, field, fields...)
+}
+
+func (b *Backend) hdel(key string, field string, fields ...string) error {
+	h, ok := b.m[key].(map[string]string)
+	if !ok {
+		return nil
+	}
+	delete(h, field)
+	for _, field := range fields {
+		delete(h, field)
+	}
+	if len(h) == 0 {
+		delete(b.m, key)
+	}
+	return nil
+}
+
+func (b *Backend) HGet(key, field string) (*string, error) {
+	m, err := b.HGetAll(key)
+	if err != nil {
+		return nil, err
+	}
+	if v, ok := m[field]; ok {
+		return &v, nil
+	}
+	return nil, nil
+}
+
+func (b *Backend) HGetAll(key string) (map[string]string, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	h, ok := b.m[key].(map[string]string)
+	if !ok {
+		return nil, nil
+	}
+	return h, nil
 }
 
 func (b *Backend) SetNX(key string, value interface{}) (bool, error) {

--- a/redisstore/atomic_write_operation.go
+++ b/redisstore/atomic_write_operation.go
@@ -138,14 +138,14 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 	})
 }
 
-func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
 	placeholders := make([]string, 2*(len(fields)+1))
 	for i := 0; i < len(placeholders); i++ {
 		placeholders[i] = fmt.Sprintf("$%v", i)
 	}
 	args := make([]interface{}, 0, 2*(len(fields)+1))
-	args = append(args, field.Key)
-	args = append(args, field.Value)
+	args = append(args, field)
+	args = append(args, value)
 	for _, field := range fields {
 		args = append(args, field.Key)
 		args = append(args, field.Value)

--- a/redisstore/atomic_write_operation.go
+++ b/redisstore/atomic_write_operation.go
@@ -138,6 +138,44 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 	})
 }
 
+func (op *AtomicWriteOperation) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) keyvaluestore.AtomicWriteResult {
+	placeholders := make([]string, 2*(len(fields)+1))
+	for i := 0; i < len(placeholders); i++ {
+		placeholders[i] = fmt.Sprintf("$%v", i)
+	}
+	args := make([]interface{}, 0, 2*(len(fields)+1))
+	args = append(args, field.Key)
+	args = append(args, field.Value)
+	for _, field := range fields {
+		args = append(args, field.Key)
+		args = append(args, field.Value)
+	}
+	return op.write(&atomicWriteOperation{
+		key:       key,
+		condition: "true",
+		write:     "redis.call('hset', $@, " + strings.Join(placeholders, ", ") + ")",
+		args:      args,
+	})
+}
+
+func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string) keyvaluestore.AtomicWriteResult {
+	placeholders := make([]string, 1+len(fields))
+	for i := 0; i < len(placeholders); i++ {
+		placeholders[i] = fmt.Sprintf("$%v", i)
+	}
+	args := make([]interface{}, 0, len(fields)+1)
+	args = append(args, field)
+	for _, field := range fields {
+		args = append(args, field)
+	}
+	return op.write(&atomicWriteOperation{
+		key:       key,
+		condition: "true",
+		write:     "redis.call('hdel', $@, " + strings.Join(placeholders, ", ") + ")",
+		args:      args,
+	})
+}
+
 func preprocessAtomicWriteExpression(in string, keyIndex, argsOffset, numArgs int) string {
 	out := strings.Replace(in, "$@", fmt.Sprintf("KEYS[%d]", keyIndex), -1)
 	for i := numArgs - 1; i >= 0; i-- {

--- a/redisstore/backend.go
+++ b/redisstore/backend.go
@@ -70,6 +70,35 @@ func (b *Backend) SMembers(key string) ([]string, error) {
 	return b.Client.SMembers(key).Result()
 }
 
+func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+	m := make(map[string]interface{}, len(fields)+1)
+	m[field.Key] = field.Value
+	for _, f := range fields {
+		m[f.Key] = f.Value
+	}
+	return b.Client.HMSet(key, m).Err()
+}
+
+func (b *Backend) HDel(key string, field string, fields ...string) error {
+	args := make([]string, 0, len(fields)+1)
+	args = append(append(args, field), fields...)
+	return b.Client.HDel(key, args...).Err()
+}
+
+func (b *Backend) HGet(key, field string) (*string, error) {
+	v, err := b.Client.HGet(key, field).Result()
+	if err == redis.Nil {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &v, err
+}
+
+func (b *Backend) HGetAll(key string) (map[string]string, error) {
+	return b.Client.HGetAll(key).Result()
+}
+
 func (b *Backend) SetNX(key string, value interface{}) (bool, error) {
 	return b.Client.SetNX(key, value, 0).Result()
 }

--- a/redisstore/backend.go
+++ b/redisstore/backend.go
@@ -70,9 +70,9 @@ func (b *Backend) SMembers(key string) ([]string, error) {
 	return b.Client.SMembers(key).Result()
 }
 
-func (b *Backend) HSet(key string, field keyvaluestore.KeyValue, fields ...keyvaluestore.KeyValue) error {
+func (b *Backend) HSet(key, field string, value interface{}, fields ...keyvaluestore.KeyValue) error {
 	m := make(map[string]interface{}, len(fields)+1)
-	m[field.Key] = field.Value
+	m[field] = value
 	for _, f := range fields {
 		m[f.Key] = f.Value
 	}


### PR DESCRIPTION
Like sets, but with extra data associated with each member.

See https://redis.io/commands/hset and friends.

For example, storing memberships:

If you have a membership object like...

```go
type Membership struct {
    UserId string
    GroupId string
    Type MembershipType
}
```

You can store it via something like...

```go
HSet("group_members:" + m.GroupId, m.UserId, serializedMembership)
```

This stores the membership type and whatever other associated data you have along with it. To delete the membership, you don't need the type. Just:

```go
HDel("group_members:" + m.GroupId, m.UserId)
```

This can also be done in transactions.