### PR TITLE
sorted hash

### DIFF
--- a/atomic_write_operation.go
+++ b/atomic_write_operation.go
@@ -33,7 +33,8 @@ type AtomicWriteOperation interface {
 	// number instead. No conditionals are applied.
 	IncrBy(key string, n int64) AtomicWriteResult
 
-	// Adds a member to a sorted set. No conditionals are applied.
+	// Add to or create a sorted set. The size of the member may be limited by some backends (for
+	// example, DynamoDB limits it to approximately 1024 bytes). No conditionals are applied.
 	ZAdd(key string, member interface{}, score float64) AtomicWriteResult
 
 	// Adds a member to a sorted set. The atomic write operation will be aborted if the member
@@ -42,6 +43,18 @@ type AtomicWriteOperation interface {
 
 	// Removes a member from a sorted set. No conditionals are applied.
 	ZRem(key string, member interface{}) AtomicWriteResult
+
+	// Add to or create a sorted hash. A sorted hash is like a cross between a hash and sorted set.
+	// It uses a field name instead of the member for the purposes of identifying and
+	// lexicographically sorting members.
+	//
+	// With DynamoDB, the field is limited to approximately 1024 bytes while the member is not.
+	//
+	// No conditionals are applied.
+	ZHAdd(key, field string, member interface{}) AtomicWriteResult
+
+	// Removes a member from a sorted hash. No conditionals are applied.
+	ZHRem(key, field string) AtomicWriteResult
 
 	// Adds a member to a set. No conditionals are applied.
 	SAdd(key string, member interface{}, members ...interface{}) AtomicWriteResult

--- a/atomic_write_operation.go
+++ b/atomic_write_operation.go
@@ -51,7 +51,7 @@ type AtomicWriteOperation interface {
 	// With DynamoDB, the field is limited to approximately 1024 bytes while the member is not.
 	//
 	// No conditionals are applied.
-	ZHAdd(key, field string, member interface{}) AtomicWriteResult
+	ZHAdd(key, field string, member interface{}, score float64) AtomicWriteResult
 
 	// Removes a member from a sorted hash. No conditionals are applied.
 	ZHRem(key, field string) AtomicWriteResult

--- a/backend.go
+++ b/backend.go
@@ -107,10 +107,22 @@ type Backend interface {
 	// lexicographically sorting members.
 	//
 	// With DynamoDB, the field is limited to approximately 1024 bytes while the member is not.
-	ZHAdd(key, field string, member interface{}) error
+	ZHAdd(key, field string, member interface{}, score float64) error
 
 	// Remove from a sorted hash.
 	ZHRem(key, field string) error
+
+	// Get members of a sorted hash by ascending score.
+	ZHRangeByScore(key string, min, max float64, limit int) ([]string, error)
+
+	// Get members (and their scores) of a sorted hash by ascending score.
+	ZHRangeByScoreWithScores(key string, min, max float64, limit int) (ScoredMembers, error)
+
+	// Get members of a sorted hash by descending score.
+	ZHRevRangeByScore(key string, min, max float64, limit int) ([]string, error)
+
+	// Get members (and their scores) of a sorted hash by descending score.
+	ZHRevRangeByScoreWithScores(key string, min, max float64, limit int) (ScoredMembers, error)
 
 	// Get members of a sorted hash by their fields' lexicographical order. All members of the set
 	// must have been added with a zero score. min and max must begin with '(' or '[' to indicate

--- a/backend.go
+++ b/backend.go
@@ -56,7 +56,8 @@ type Backend interface {
 	// Gets all fields of the hash at the given key.
 	HGetAll(key string) (map[string]string, error)
 
-	// Add to or create a sorted set.
+	// Add to or create a sorted set. The size of the member may be limited by some backends (for
+	// example, DynamoDB limits it to approximately 1024 bytes).
 	ZAdd(key string, member interface{}, score float64) error
 
 	// Gets the score for a member added via ZAdd.
@@ -100,6 +101,28 @@ type Backend interface {
 	// exclusive or inclusive. Alternatively, min can be "-" and max can be "+" to represent
 	// infinities.
 	ZRevRangeByLex(key string, min, max string, limit int) ([]string, error)
+
+	// Add to or create a sorted hash. A sorted hash is like a cross between a hash and sorted set.
+	// It uses a field name instead of the member for the purposes of identifying and
+	// lexicographically sorting members.
+	//
+	// With DynamoDB, the field is limited to approximately 1024 bytes while the member is not.
+	ZHAdd(key, field string, member interface{}) error
+
+	// Remove from a sorted hash.
+	ZHRem(key, field string) error
+
+	// Get members of a sorted hash by their fields' lexicographical order. All members of the set
+	// must have been added with a zero score. min and max must begin with '(' or '[' to indicate
+	// exclusive or inclusive. Alternatively, min can be "-" and max can be "+" to represent
+	// infinities.
+	ZHRangeByLex(key string, min, max string, limit int) ([]string, error)
+
+	// Get members of a sorted hash by their fields' reverse lexicographical order. All members of
+	// the set must have been added with a zero score. min and max must begin with '(' or '[' to
+	// indicate exclusive or inclusive. Alternatively, min can be "-" and max can be "+" to
+	// represent infinities.
+	ZHRevRangeByLex(key string, min, max string, limit int) ([]string, error)
 }
 
 type ScoredMembers []*ScoredMember

--- a/dynamodbstore/atomic_write_operation.go
+++ b/dynamodbstore/atomic_write_operation.go
@@ -132,6 +132,19 @@ func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float
 	})
 }
 
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+	s := *keyvaluestore.ToString(member)
+	return op.write(dynamodb.TransactWriteItem{
+		Put: &dynamodb.Put{
+			TableName: &op.Backend.TableName,
+			Item: newItem(key, field, map[string]*dynamodb.AttributeValue{
+				"v":   attributeValue(s),
+				"rk2": attributeValue(floatSortKey(0.0) + field),
+			}),
+		},
+	})
+}
+
 func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	s := *keyvaluestore.ToString(member)
 	return op.write(dynamodb.TransactWriteItem{
@@ -148,10 +161,14 @@ func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score flo
 
 func (op *AtomicWriteOperation) ZRem(key string, member interface{}) keyvaluestore.AtomicWriteResult {
 	s := *keyvaluestore.ToString(member)
+	return op.ZHRem(key, s)
+}
+
+func (op *AtomicWriteOperation) ZHRem(key, field string) keyvaluestore.AtomicWriteResult {
 	return op.write(dynamodb.TransactWriteItem{
 		Delete: &dynamodb.Delete{
 			TableName: &op.Backend.TableName,
-			Key:       compositeKey(key, s),
+			Key:       compositeKey(key, field),
 		},
 	})
 }

--- a/dynamodbstore/atomic_write_operation.go
+++ b/dynamodbstore/atomic_write_operation.go
@@ -121,25 +121,17 @@ func (op *AtomicWriteOperation) IncrBy(key string, n int64) keyvaluestore.Atomic
 
 func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	s := *keyvaluestore.ToString(member)
-	return op.write(dynamodb.TransactWriteItem{
-		Put: &dynamodb.Put{
-			TableName: &op.Backend.TableName,
-			Item: newItem(key, s, map[string]*dynamodb.AttributeValue{
-				"v":   attributeValue(s),
-				"rk2": attributeValue(floatSortKey(score) + s),
-			}),
-		},
-	})
+	return op.ZHAdd(key, s, s, score)
 }
 
-func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	s := *keyvaluestore.ToString(member)
 	return op.write(dynamodb.TransactWriteItem{
 		Put: &dynamodb.Put{
 			TableName: &op.Backend.TableName,
 			Item: newItem(key, field, map[string]*dynamodb.AttributeValue{
 				"v":   attributeValue(s),
-				"rk2": attributeValue(floatSortKey(0.0) + field),
+				"rk2": attributeValue(floatSortKey(score) + field),
 			}),
 		},
 	})

--- a/dynamodbstore/backend.go
+++ b/dynamodbstore/backend.go
@@ -448,25 +448,16 @@ func floatSortKeyAfter(f float64) string {
 
 func (b *Backend) ZAdd(key string, member interface{}, score float64) error {
 	s := *keyvaluestore.ToString(member)
-	if _, err := b.Client.PutItem(&dynamodb.PutItemInput{
-		TableName: aws.String(b.TableName),
-		Item: newItem(key, s, map[string]*dynamodb.AttributeValue{
-			"v":   attributeValue(s),
-			"rk2": attributeValue(floatSortKey(score) + s),
-		}),
-	}); err != nil {
-		return errors.Wrap(err, "dynamodb put item request error")
-	}
-	return nil
+	return b.ZHAdd(key, s, s, score)
 }
 
-func (b *Backend) ZHAdd(key, field string, member interface{}) error {
+func (b *Backend) ZHAdd(key, field string, member interface{}, score float64) error {
 	s := *keyvaluestore.ToString(member)
 	if _, err := b.Client.PutItem(&dynamodb.PutItemInput{
 		TableName: aws.String(b.TableName),
 		Item: newItem(key, field, map[string]*dynamodb.AttributeValue{
 			"v":   attributeValue(s),
-			"rk2": attributeValue(floatSortKey(0.0) + field),
+			"rk2": attributeValue(floatSortKey(score) + field),
 		}),
 	}); err != nil {
 		return errors.Wrap(err, "dynamodb put item request error")
@@ -624,8 +615,16 @@ func (b *Backend) ZRangeByScore(key string, min, max float64, limit int) ([]stri
 	return members.Values(), err
 }
 
+func (b *Backend) ZHRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	return b.ZRangeByScore(key, min, max, limit)
+}
+
 func (b *Backend) ZRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	return b.zRangeByScoreWithScores(key, min, max, limit)
+}
+
+func (b *Backend) ZHRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return b.ZRangeByScoreWithScores(key, min, max, limit)
 }
 
 func (b *Backend) zRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
@@ -638,8 +637,16 @@ func (b *Backend) ZRevRangeByScore(key string, min, max float64, limit int) ([]s
 	return members.Values(), err
 }
 
+func (b *Backend) ZHRevRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	return b.ZRevRangeByScore(key, min, max, limit)
+}
+
 func (b *Backend) ZRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	return b.zRevRangeByScoreWithScores(key, min, max, limit)
+}
+
+func (b *Backend) ZHRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return b.ZRevRangeByScoreWithScores(key, min, max, limit)
 }
 
 func (b *Backend) zRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {

--- a/keyvaluestorecache/atomic_write_operation.go
+++ b/keyvaluestorecache/atomic_write_operation.go
@@ -49,6 +49,11 @@ func (op *readCacheAtomicWriteOperation) ZAdd(key string, member interface{}, sc
 	return op.atomicWrite.ZAdd(key, member, score)
 }
 
+func (op *readCacheAtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+	op.invalidations = append(op.invalidations, key)
+	return op.atomicWrite.ZHAdd(key, field, member)
+}
+
 func (op *readCacheAtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	op.invalidations = append(op.invalidations, key)
 	return op.atomicWrite.ZAddNX(key, member, score)
@@ -57,6 +62,11 @@ func (op *readCacheAtomicWriteOperation) ZAddNX(key string, member interface{}, 
 func (op *readCacheAtomicWriteOperation) ZRem(key string, member interface{}) keyvaluestore.AtomicWriteResult {
 	op.invalidations = append(op.invalidations, key)
 	return op.atomicWrite.ZRem(key, member)
+}
+
+func (op *readCacheAtomicWriteOperation) ZHRem(key, field string) keyvaluestore.AtomicWriteResult {
+	op.invalidations = append(op.invalidations, key)
+	return op.atomicWrite.ZHRem(key, field)
 }
 
 func (op *readCacheAtomicWriteOperation) SAdd(key string, member interface{}, members ...interface{}) keyvaluestore.AtomicWriteResult {

--- a/keyvaluestorecache/atomic_write_operation.go
+++ b/keyvaluestorecache/atomic_write_operation.go
@@ -49,9 +49,9 @@ func (op *readCacheAtomicWriteOperation) ZAdd(key string, member interface{}, sc
 	return op.atomicWrite.ZAdd(key, member, score)
 }
 
-func (op *readCacheAtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+func (op *readCacheAtomicWriteOperation) ZHAdd(key, field string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	op.invalidations = append(op.invalidations, key)
-	return op.atomicWrite.ZHAdd(key, field, member)
+	return op.atomicWrite.ZHAdd(key, field, member, score)
 }
 
 func (op *readCacheAtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {

--- a/keyvaluestorecache/read_cache.go
+++ b/keyvaluestorecache/read_cache.go
@@ -225,8 +225,8 @@ func (c *ReadCache) ZAdd(key string, member interface{}, score float64) error {
 	return err
 }
 
-func (c *ReadCache) ZHAdd(key, field string, member interface{}) error {
-	err := c.backend.ZHAdd(key, field, member)
+func (c *ReadCache) ZHAdd(key, field string, member interface{}, score float64) error {
+	err := c.backend.ZHAdd(key, field, member, score)
 	c.Invalidate(key)
 	return err
 }
@@ -345,8 +345,17 @@ func (c *ReadCache) ZRangeByScore(key string, min, max float64, limit int) ([]st
 	return members.Values(), err
 }
 
+func (c *ReadCache) ZHRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	members, err := c.ZHRangeByScoreWithScores(key, min, max, limit)
+	return members.Values(), err
+}
+
 func (c *ReadCache) ZRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	return c.zRangeByScoreWithScores("zrbs", c.backend.ZRangeByScoreWithScores, key, min, max, limit)
+}
+
+func (c *ReadCache) ZHRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return c.zRangeByScoreWithScores("zrbs", c.backend.ZHRangeByScoreWithScores, key, min, max, limit)
 }
 
 func (c *ReadCache) zRangeByScoreWithScores(cacheKey string, f func(string, float64, float64, int) (keyvaluestore.ScoredMembers, error), key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
@@ -376,8 +385,17 @@ func (c *ReadCache) ZRevRangeByScore(key string, min, max float64, limit int) ([
 	return members.Values(), err
 }
 
+func (c *ReadCache) ZHRevRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	members, err := c.ZHRevRangeByScoreWithScores(key, min, max, limit)
+	return members.Values(), err
+}
+
 func (c *ReadCache) ZRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	return c.zRangeByScoreWithScores("zrrbs", c.backend.ZRevRangeByScoreWithScores, key, min, max, limit)
+}
+
+func (c *ReadCache) ZHRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return c.zRangeByScoreWithScores("zrrbs", c.backend.ZHRevRangeByScoreWithScores, key, min, max, limit)
 }
 
 func (c *ReadCache) ZRangeByLex(key string, min, max string, limit int) ([]string, error) {

--- a/memorystore/atomic_write_operation.go
+++ b/memorystore/atomic_write_operation.go
@@ -99,20 +99,14 @@ func (op *AtomicWriteOperation) IncrBy(key string, n int64) keyvaluestore.Atomic
 
 func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	s := *keyvaluestore.ToString(member)
-	return op.write(&atomicWriteOperation{
-		write: func() {
-			op.Backend.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
-				return score, nil
-			})
-		},
-	})
+	return op.ZHAdd(key, s, s, score)
 }
 
-func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
 		write: func() {
 			op.Backend.zhadd(key, field, member, func(previousScore *float64) (float64, error) {
-				return 0.0, nil
+				return score, nil
 			})
 		},
 	})

--- a/memorystore/atomic_write_operation.go
+++ b/memorystore/atomic_write_operation.go
@@ -98,22 +98,34 @@ func (op *AtomicWriteOperation) IncrBy(key string, n int64) keyvaluestore.Atomic
 }
 
 func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
+	s := *keyvaluestore.ToString(member)
 	return op.write(&atomicWriteOperation{
 		write: func() {
-			op.Backend.zadd(key, member, func(previousScore *float64) (float64, error) {
+			op.Backend.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
 				return score, nil
 			})
 		},
 	})
 }
 
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+	return op.write(&atomicWriteOperation{
+		write: func() {
+			op.Backend.zhadd(key, field, member, func(previousScore *float64) (float64, error) {
+				return 0.0, nil
+			})
+		},
+	})
+}
+
 func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
+	s := *keyvaluestore.ToString(member)
 	return op.write(&atomicWriteOperation{
 		condition: func() bool {
 			return op.Backend.zscore(key, member) == nil
 		},
 		write: func() {
-			op.Backend.zadd(key, member, func(previousScore *float64) (float64, error) {
+			op.Backend.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
 				return score, nil
 			})
 		},
@@ -121,9 +133,14 @@ func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score flo
 }
 
 func (op *AtomicWriteOperation) ZRem(key string, member interface{}) keyvaluestore.AtomicWriteResult {
+	s := *keyvaluestore.ToString(member)
+	return op.ZHRem(key, s)
+}
+
+func (op *AtomicWriteOperation) ZHRem(key, field string) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
 		write: func() {
-			op.Backend.zrem(key, member)
+			op.Backend.zhrem(key, field)
 		},
 	})
 }

--- a/memorystore/backend.go
+++ b/memorystore/backend.go
@@ -334,22 +334,16 @@ func (b *Backend) zhadd(key, field string, member interface{}, f func(previousSc
 }
 
 func (b *Backend) ZAdd(key string, member interface{}, score float64) error {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
 	s := *keyvaluestore.ToString(member)
-	_, err := b.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
-		return score, nil
-	})
-	return err
+	return b.ZHAdd(key, s, s, score)
 }
 
-func (b *Backend) ZHAdd(key, field string, member interface{}) error {
+func (b *Backend) ZHAdd(key, field string, member interface{}, score float64) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
 	_, err := b.zhadd(key, field, member, func(previousScore *float64) (float64, error) {
-		return 0.0, nil
+		return score, nil
 	})
 	return err
 }
@@ -427,11 +421,19 @@ func (b *Backend) ZRangeByScore(key string, min, max float64, limit int) ([]stri
 	}
 }
 
+func (b *Backend) ZHRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	return b.ZRangeByScore(key, min, max, limit)
+}
+
 func (b *Backend) ZRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
 	return b.zRangeByScoreWithScores(key, min, max, limit)
+}
+
+func (b *Backend) ZHRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return b.ZRangeByScoreWithScores(key, min, max, limit)
 }
 
 func (b *Backend) zRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
@@ -474,11 +476,19 @@ func (b *Backend) ZRevRangeByScore(key string, min, max float64, limit int) ([]s
 	}
 }
 
+func (b *Backend) ZHRevRangeByScore(key string, min, max float64, limit int) ([]string, error) {
+	return b.ZRevRangeByScore(key, min, max, limit)
+}
+
 func (b *Backend) ZRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
 	return b.zRevRangeByScoreWithScores(key, min, max, limit)
+}
+
+func (b *Backend) ZHRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {
+	return b.ZRevRangeByScoreWithScores(key, min, max, limit)
 }
 
 func (b *Backend) zRevRangeByScoreWithScores(key string, min, max float64, limit int) (keyvaluestore.ScoredMembers, error) {

--- a/memorystore/backend.go
+++ b/memorystore/backend.go
@@ -304,8 +304,7 @@ type sortedSet struct {
 	m              *immutable.OrderedMap
 }
 
-func (b *Backend) zadd(key string, member interface{}, f func(previousScore *float64) (float64, error)) (float64, error) {
-	v := *keyvaluestore.ToString(member)
+func (b *Backend) zhadd(key, field string, member interface{}, f func(previousScore *float64) (float64, error)) (float64, error) {
 	s, _ := b.m[key].(*sortedSet)
 	if s == nil {
 		s = &sortedSet{
@@ -315,8 +314,8 @@ func (b *Backend) zadd(key string, member interface{}, f func(previousScore *flo
 
 	var previousScore *float64
 
-	if prev, ok := s.scoresByMember[v]; ok {
-		s.m = s.m.Delete(floatSortKey(prev) + v)
+	if prev, ok := s.scoresByMember[field]; ok {
+		s.m = s.m.Delete(floatSortKey(prev) + field)
 		previousScore = &prev
 	}
 
@@ -325,8 +324,9 @@ func (b *Backend) zadd(key string, member interface{}, f func(previousScore *flo
 	if err != nil {
 		return 0, err
 	} else {
-		s.m = s.m.Set(floatSortKey(newScore)+v, v)
-		s.scoresByMember[v] = newScore
+		v := *keyvaluestore.ToString(member)
+		s.m = s.m.Set(floatSortKey(newScore)+field, v)
+		s.scoresByMember[field] = newScore
 	}
 
 	b.m[key] = s
@@ -337,8 +337,19 @@ func (b *Backend) ZAdd(key string, member interface{}, score float64) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	_, err := b.zadd(key, member, func(previousScore *float64) (float64, error) {
+	s := *keyvaluestore.ToString(member)
+	_, err := b.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
 		return score, nil
+	})
+	return err
+}
+
+func (b *Backend) ZHAdd(key, field string, member interface{}) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	_, err := b.zhadd(key, field, member, func(previousScore *float64) (float64, error) {
+		return 0.0, nil
 	})
 	return err
 }
@@ -361,7 +372,8 @@ func (b *Backend) ZIncrBy(key string, member string, n float64) (float64, error)
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	return b.zadd(key, member, func(previousScore *float64) (float64, error) {
+	s := *keyvaluestore.ToString(member)
+	return b.zhadd(key, s, s, func(previousScore *float64) (float64, error) {
 		if previousScore != nil {
 			return *previousScore + n, nil
 		}
@@ -382,18 +394,22 @@ func (b *Backend) zscore(key string, member interface{}) *float64 {
 }
 
 func (b *Backend) ZRem(key string, member interface{}) error {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-	return b.zrem(key, member)
+	s := *keyvaluestore.ToString(member)
+	return b.ZHRem(key, s)
 }
 
-func (b *Backend) zrem(key string, member interface{}) error {
+func (b *Backend) ZHRem(key, field string) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.zhrem(key, field)
+}
+
+func (b *Backend) zhrem(key, field string) error {
 	s, _ := b.m[key].(*sortedSet)
 	if s != nil {
-		v := *keyvaluestore.ToString(member)
-		if previous, ok := s.scoresByMember[v]; ok {
-			s.m = s.m.Delete(floatSortKey(previous) + v)
-			delete(s.scoresByMember, v)
+		if previous, ok := s.scoresByMember[field]; ok {
+			s.m = s.m.Delete(floatSortKey(previous) + field)
+			delete(s.scoresByMember, field)
 			b.m[key] = s
 		}
 	}
@@ -524,25 +540,29 @@ func (b *Backend) ZRangeByLex(key string, min, max string, limit int) ([]string,
 		next = s.m.MinAfter(sortKeyPrefix + min[1:])
 		if min[0] == '[' {
 			if next == nil {
-				if x := s.m.Max(); x != nil && x.Value().(string) == min[1:] {
+				if x := s.m.Max(); x != nil && x.Key().(string)[len(sortKeyPrefix):] == min[1:] {
 					next = x
 				}
-			} else if x := next.Prev(); x != nil && x.Value().(string) == min[1:] {
+			} else if x := next.Prev(); x != nil && x.Key().(string)[len(sortKeyPrefix):] == min[1:] {
 				next = x
 			}
 		}
 	}
 
 	for (limit == 0 || len(results) < limit) && next != nil {
-		v := next.Value().(string)
-		if max != "+" && (v > max[1:] || (max[0] == '(' && v == max[1:])) {
+		lex := next.Key().(string)[len(sortKeyPrefix):]
+		if max != "+" && (lex > max[1:] || (max[0] == '(' && lex == max[1:])) {
 			break
 		}
-		results = append(results, v)
+		results = append(results, next.Value().(string))
 		next = next.Next()
 	}
 
 	return results, nil
+}
+
+func (b *Backend) ZHRangeByLex(key string, min, max string, limit int) ([]string, error) {
+	return b.ZRangeByLex(key, min, max, limit)
 }
 
 func (b *Backend) ZRevRangeByLex(key string, min, max string, limit int) ([]string, error) {
@@ -565,23 +585,27 @@ func (b *Backend) ZRevRangeByLex(key string, min, max string, limit int) ([]stri
 		next = s.m.MaxBefore(sortKeyPrefix + max[1:])
 		if max[0] == '[' {
 			if next == nil {
-				if x := s.m.Min(); x != nil && x.Value().(string) == min[1:] {
+				if x := s.m.Min(); x != nil && x.Key().(string)[len(sortKeyPrefix):] == min[1:] {
 					next = x
 				}
-			} else if x := next.Next(); x != nil && x.Value().(string) == max[1:] {
+			} else if x := next.Next(); x != nil && x.Key().(string)[len(sortKeyPrefix):] == max[1:] {
 				next = x
 			}
 		}
 	}
 
 	for (limit == 0 || len(results) < limit) && next != nil {
-		v := next.Value().(string)
-		if min != "-" && (v < min[1:] || (min[0] == '(' && v == min[1:])) {
+		lex := next.Key().(string)[len(sortKeyPrefix):]
+		if min != "-" && (lex < min[1:] || (min[0] == '(' && lex == min[1:])) {
 			break
 		}
-		results = append(results, v)
+		results = append(results, next.Value().(string))
 		next = next.Prev()
 	}
 
 	return results, nil
+}
+
+func (b *Backend) ZHRevRangeByLex(key string, min, max string, limit int) ([]string, error) {
+	return b.ZRevRangeByLex(key, min, max, limit)
 }

--- a/redisstore/atomic_write_operation.go
+++ b/redisstore/atomic_write_operation.go
@@ -16,7 +16,7 @@ type AtomicWriteOperation struct {
 }
 
 type atomicWriteOperation struct {
-	key       string
+	keys      []string
 	condition string
 	write     string
 	args      []interface{}
@@ -35,105 +35,107 @@ func (op *AtomicWriteOperation) write(wOp *atomicWriteOperation) keyvaluestore.A
 
 func (op *AtomicWriteOperation) Set(key string, value interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('set', $@, $0)",
+		write:     "redis.call('set', @0, $0)",
 		args:      []interface{}{value},
 	})
 }
 
 func (op *AtomicWriteOperation) SetNX(key string, value interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('exists', $@) == 0",
-		write:     "redis.call('set', $@, $0)",
+		keys:      []string{key},
+		condition: "redis.call('exists', @0) == 0",
+		write:     "redis.call('set', @0, $0)",
 		args:      []interface{}{value},
 	})
 }
 
 func (op *AtomicWriteOperation) SetXX(key string, value interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('exists', $@) == 1",
-		write:     "redis.call('set', $@, $0)",
+		keys:      []string{key},
+		condition: "redis.call('exists', @0) == 1",
+		write:     "redis.call('set', @0, $0)",
 		args:      []interface{}{value},
 	})
 }
 
 func (op *AtomicWriteOperation) SetEQ(key string, value, oldValue interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('get', $@) == $0",
-		write:     "redis.call('set', $@, $1)",
+		keys:      []string{key},
+		condition: "redis.call('get', @0) == $0",
+		write:     "redis.call('set', @0, $1)",
 		args:      []interface{}{oldValue, value},
 	})
 }
 
 func (op *AtomicWriteOperation) Delete(key string) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('del', $@)",
+		write:     "redis.call('del', @0)",
 	})
 }
 
 func (op *AtomicWriteOperation) DeleteXX(key string) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('exists', $@) == 1",
-		write:     "redis.call('del', $@)",
+		keys:      []string{key},
+		condition: "redis.call('exists', @0) == 1",
+		write:     "redis.call('del', @0)",
 	})
 }
 
 func (op *AtomicWriteOperation) IncrBy(key string, n int64) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('incrby', $@, $0)",
+		write:     "redis.call('incrby', @0, $0)",
 		args:      []interface{}{n},
 	})
 }
 
 func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('zadd', $@, $1, $0)",
+		write:     "redis.call('zadd', @0, $1, $0)",
 		args:      []interface{}{member, score},
 	})
 }
 
-func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
-	s := *keyvaluestore.ToString(member)
-	return op.ZAdd(key, encodeZHField(field, true)+s, 0.0)
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
+	return op.write(&atomicWriteOperation{
+		keys:      []string{key, zhHashKey(key)},
+		condition: "true",
+		write:     "redis.call('zadd', @0, $1, $0)\nredis.call('hset', @1, $0, $2)",
+		args:      []interface{}{field, score, member},
+	})
 }
 
 func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('zscore', $@, $0) == false",
-		write:     "redis.call('zadd', $@, $1, $0)",
+		keys:      []string{key},
+		condition: "redis.call('zscore', @0, $0) == false",
+		write:     "redis.call('zadd', @0, $1, $0)",
 		args:      []interface{}{member, score},
 	})
 }
 
 func (op *AtomicWriteOperation) ZRem(key string, member interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('zrem', $@, $0)",
+		write:     "redis.call('zrem', @0, $0)",
 		args:      []interface{}{member},
 	})
 }
 
 func (op *AtomicWriteOperation) ZHRem(key, field string) keyvaluestore.AtomicWriteResult {
-	min := "[" + encodeZHField(field, true)
-	max := "(" + encodeZHField(field, false)
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key, zhHashKey(key)},
 		condition: "true",
-		write:     "redis.call('zremrangebylex', $@, $0, $1)",
-		args:      []interface{}{min, max},
+		write:     "redis.call('zrem', @0, $0)\nredis.call('hdel', @1, $0)",
+		args:      []interface{}{field},
 	})
 }
 
@@ -143,9 +145,9 @@ func (op *AtomicWriteOperation) SAdd(key string, member interface{}, members ...
 		placeholders[i] = fmt.Sprintf("$%v", i)
 	}
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('sadd', $@, " + strings.Join(placeholders, ", ") + ")",
+		write:     "redis.call('sadd', @0, " + strings.Join(placeholders, ", ") + ")",
 		args:      append([]interface{}{member}, members...),
 	})
 }
@@ -156,9 +158,9 @@ func (op *AtomicWriteOperation) SRem(key string, member interface{}, members ...
 		placeholders[i] = fmt.Sprintf("$%v", i)
 	}
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('srem', $@, " + strings.Join(placeholders, ", ") + ")",
+		write:     "redis.call('srem', @0, " + strings.Join(placeholders, ", ") + ")",
 		args:      append([]interface{}{member}, members...),
 	})
 }
@@ -176,18 +178,18 @@ func (op *AtomicWriteOperation) HSet(key, field string, value interface{}, field
 		args = append(args, field.Value)
 	}
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('hset', $@, " + strings.Join(placeholders, ", ") + ")",
+		write:     "redis.call('hset', @0, " + strings.Join(placeholders, ", ") + ")",
 		args:      args,
 	})
 }
 
 func (op *AtomicWriteOperation) HSetNX(key, field string, value interface{}) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
-		key:       key,
-		condition: "redis.call('hexists', $@, $0) == 0",
-		write:     "redis.call('hset', $@, $0, $1)",
+		keys:      []string{key},
+		condition: "redis.call('hexists', @0, $0) == 0",
+		write:     "redis.call('hset', @0, $0, $1)",
 		args:      []interface{}{field, value},
 	})
 }
@@ -203,15 +205,18 @@ func (op *AtomicWriteOperation) HDel(key string, field string, fields ...string)
 		args = append(args, field)
 	}
 	return op.write(&atomicWriteOperation{
-		key:       key,
+		keys:      []string{key},
 		condition: "true",
-		write:     "redis.call('hdel', $@, " + strings.Join(placeholders, ", ") + ")",
+		write:     "redis.call('hdel', @0, " + strings.Join(placeholders, ", ") + ")",
 		args:      args,
 	})
 }
 
-func preprocessAtomicWriteExpression(in string, keyIndex, argsOffset, numArgs int) string {
-	out := strings.Replace(in, "$@", fmt.Sprintf("KEYS[%d]", keyIndex), -1)
+func preprocessAtomicWriteExpression(in string, keysOffset, numKeys int, argsOffset, numArgs int) string {
+	out := in
+	for i := numKeys - 1; i >= 0; i-- {
+		out = strings.Replace(out, fmt.Sprintf("@%d", i), fmt.Sprintf("KEYS[%d]", keysOffset+i+1), -1)
+	}
 	for i := numArgs - 1; i >= 0; i-- {
 		out = strings.Replace(out, fmt.Sprintf("$%d", i), fmt.Sprintf("ARGV[%d]", argsOffset+i+1), -1)
 	}
@@ -223,15 +228,15 @@ func (op *AtomicWriteOperation) Exec() (bool, error) {
 		return false, fmt.Errorf("max operation count exceeded")
 	}
 
-	keys := make([]string, len(op.operations))
+	var keys []string
 	var args []interface{}
 	writeExpressions := make([]string, len(op.operations))
 
 	script := []string{"local checks = {}"}
 	for i, op := range op.operations {
-		script = append(script, fmt.Sprintf("checks[%d] = %s", i+1, preprocessAtomicWriteExpression(op.condition, i+1, len(args), len(op.args))))
-		writeExpressions[i] = preprocessAtomicWriteExpression(op.write, i+1, len(args), len(op.args))
-		keys[i] = op.key
+		script = append(script, fmt.Sprintf("checks[%d] = %s", i+1, preprocessAtomicWriteExpression(op.condition, len(keys), len(op.keys), len(args), len(op.args))))
+		writeExpressions[i] = preprocessAtomicWriteExpression(op.write, len(keys), len(op.keys), len(args), len(op.args))
+		keys = append(keys, op.keys...)
 		args = append(args, op.args...)
 	}
 	script = append(script,

--- a/redisstore/atomic_write_operation.go
+++ b/redisstore/atomic_write_operation.go
@@ -103,6 +103,11 @@ func (op *AtomicWriteOperation) ZAdd(key string, member interface{}, score float
 	})
 }
 
+func (op *AtomicWriteOperation) ZHAdd(key, field string, member interface{}) keyvaluestore.AtomicWriteResult {
+	s := *keyvaluestore.ToString(member)
+	return op.ZAdd(key, encodeZHField(field, true)+s, 0.0)
+}
+
 func (op *AtomicWriteOperation) ZAddNX(key string, member interface{}, score float64) keyvaluestore.AtomicWriteResult {
 	return op.write(&atomicWriteOperation{
 		key:       key,
@@ -118,6 +123,17 @@ func (op *AtomicWriteOperation) ZRem(key string, member interface{}) keyvaluesto
 		condition: "true",
 		write:     "redis.call('zrem', $@, $0)",
 		args:      []interface{}{member},
+	})
+}
+
+func (op *AtomicWriteOperation) ZHRem(key, field string) keyvaluestore.AtomicWriteResult {
+	min := "[" + encodeZHField(field, true)
+	max := "(" + encodeZHField(field, false)
+	return op.write(&atomicWriteOperation{
+		key:       key,
+		condition: "true",
+		write:     "redis.call('zremrangebylex', $@, $0, $1)",
+		args:      []interface{}{min, max},
 	})
 }
 


### PR DESCRIPTION
This adds a new sorted hash type, which is a cross between a sorted set and a hash. On Redis, this is actually implemented as a sorted set + hash, but on DynamoDB this is implemented extremely efficiently using just one item per member. Thus it's preferable in situations where ZAdd + indirection would normally be used. It also has the benefit of being able to store much larger members in DynamoDB.

`Backend` now has the following methods:

* `ZHAdd(key, field string, member interface{}, score float64) error`
* `ZHRem(key, field string) error`
* `ZHRangeByScore(key string, min, max float64, limit int) ([]string, error)`
* `ZHRangeByScoreWithScores(key string, min, max float64, limit int) (ScoredMembers, error)`
* `ZHRevRangeByScore(key string, min, max float64, limit int) ([]string, error)`
* `ZHRevRangeByScoreWithScores(key string, min, max float64, limit int) (ScoredMembers, error)`
* `ZHRangeByLex(key string, min, max string, limit int) ([]string, error)`
* `ZHRevRangeByLex(key string, min, max string, limit int) ([]string, error)`

`AtomicWriteOperation` now has the following:

* `ZHAdd(key, field string, member interface{}, score float64) AtomicWriteResult`
* `ZHRem(key, field string) AtomicWriteResult`