### PR TITLE
changed member string to member interface for ZIncrBy

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -67,7 +67,7 @@ type Backend interface {
 	ZRem(key string, member interface{}) error
 
 	// Increment a score in a sorted set or set the score if the member doesn't exist.
-	ZIncrBy(key string, member string, n float64) (float64, error)
+	ZIncrBy(key string, member interface{}, n float64) (float64, error)
 
 	// Get members of a sorted set by ascending score.
 	ZRangeByScore(key string, min, max float64, limit int) ([]string, error)

--- a/dynamodbstore/backend.go
+++ b/dynamodbstore/backend.go
@@ -490,7 +490,7 @@ func (b *Backend) ZScore(key string, member interface{}) (*float64, error) {
 	return nil, nil
 }
 
-func (b *Backend) ZIncrBy(key string, member string, n float64) (float64, error) {
+func (b *Backend) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
 	var retValue float64
 
 	err := runContentiousMethod(func() (bool, error) {

--- a/foundationdbstore/backend.go
+++ b/foundationdbstore/backend.go
@@ -612,7 +612,7 @@ func (b *Backend) zScore(tx fdb.ReadTransaction, key string, member interface{})
 	return &score, nil
 }
 
-func (b *Backend) ZIncrBy(key string, member string, n float64) (float64, error) {
+func (b *Backend) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
 	field := *keyvaluestore.ToString(member)
 	v := []byte(field)
 	k := b.zLexKey(key, field)

--- a/keyvaluestorecache/read_cache.go
+++ b/keyvaluestorecache/read_cache.go
@@ -265,7 +265,7 @@ func (c *ReadCache) ZScore(key string, member interface{}) (*float64, error) {
 	return score, err
 }
 
-func (c *ReadCache) ZIncrBy(key string, member string, n float64) (float64, error) {
+func (c *ReadCache) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
 	val, err := c.backend.ZIncrBy(key, member, n)
 	c.Invalidate(key)
 	return val, err

--- a/keyvaluestoreinvalidator/invalidator.go
+++ b/keyvaluestoreinvalidator/invalidator.go
@@ -119,7 +119,7 @@ func (c *Invalidator) ZScore(key string, member interface{}) (*float64, error) {
 	return c.Backend.ZScore(key, member)
 }
 
-func (c *Invalidator) ZIncrBy(key string, member string, n float64) (float64, error) {
+func (c *Invalidator) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
 	val, err := c.Backend.ZIncrBy(key, member, n)
 	c.Invalidate(key)
 	return val, err

--- a/memorystore/backend.go
+++ b/memorystore/backend.go
@@ -362,7 +362,7 @@ func (b *Backend) ZScore(key string, member interface{}) (*float64, error) {
 	return nil, nil
 }
 
-func (b *Backend) ZIncrBy(key string, member string, n float64) (float64, error) {
+func (b *Backend) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 

--- a/redisstore/backend.go
+++ b/redisstore/backend.go
@@ -49,8 +49,9 @@ func (b *Backend) NIncrBy(key string, n int64) (int64, error) {
 	return b.Client.IncrBy(key, n).Result()
 }
 
-func (b *Backend) ZIncrBy(key string, member string, n float64) (float64, error) {
-	return b.Client.ZIncrBy(key, n, member).Result()
+func (b *Backend) ZIncrBy(key string, member interface{}, n float64) (float64, error) {
+	s := *keyvaluestore.ToString(member)
+	return b.Client.ZIncrBy(key, n, s).Result()
 }
 
 func (b *Backend) SAdd(key string, member interface{}, members ...interface{}) error {


### PR DESCRIPTION
Changes the `	ZIncrBy(key string, member string, n float64) (float64, error)` method to use a `member interface{}`